### PR TITLE
Add attribute to enable/disable autoclean

### DIFF
--- a/ironic/resource_ironic_node_v1.go
+++ b/ironic/resource_ironic_node_v1.go
@@ -40,6 +40,10 @@ func resourceNodeV1() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"automated_clean": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"conductor_group": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -666,6 +670,7 @@ func propertiesMerge(d *schema.ResourceData, key string) map[string]any {
 // TODO: Is there a better way to do this? Annotations?
 func schemaToCreateOpts(d *schema.ResourceData) *nodes.CreateOpts {
 	properties := propertiesMerge(d, "root_device")
+	auto_clean := d.Get("automated_clean").(bool)
 	return &nodes.CreateOpts{
 		BootInterface:       d.Get("boot_interface").(string),
 		ConductorGroup:      d.Get("conductor_group").(string),
@@ -686,6 +691,7 @@ func schemaToCreateOpts(d *schema.ResourceData) *nodes.CreateOpts {
 		ResourceClass:       d.Get("resource_class").(string),
 		StorageInterface:    d.Get("storage_interface").(string),
 		VendorInterface:     d.Get("vendor_interface").(string),
+		AutomatedClean:      &auto_clean,
 	}
 }
 

--- a/ironic/resource_ironic_node_v1_test.go
+++ b/ironic/resource_ironic_node_v1_test.go
@@ -158,6 +158,7 @@ func testAccNodeResource(extraValue string) string {
 			driver = "fake-hardware"
 
 			boot_interface = "pxe"
+			automated_clean = true
 			deploy_interface = "fake"
 			inspect_interface = "fake"
 			management_interface = "fake"


### PR DESCRIPTION
The current version of the provider does not allow disabling automated cleaning, which can make testing environments impractical. I'm adding an optional node attribute to fix this.